### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -46,7 +46,7 @@ chown -R $app:www-data "$calibre_dir"
 #=================================================
 ynh_script_progression --message="Adding a configuration file..." --weight=1
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 ynh_add_config --template="../conf/config_local.php" --destination="$install_dir/config_local.php"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -58,7 +58,7 @@ chown -R $app:www-data "$calibre_dir"
 #=================================================
 ynh_script_progression --message="Updating a configuration file..." --weight=1
 
-timezone="$(cat /etc/timezone)"
+timezone="$(timedatectl show --value --property=Timezone)"
 
 ynh_add_config --template="../conf/config_local.php" --destination="$install_dir/config_local.php"
 


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.